### PR TITLE
Bug fix: error msg for delete and edit command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -28,12 +28,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
-        try {
-            Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-            return new DeleteCommand(id);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
-        }
+        Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
+        return new DeleteCommand(id);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -53,12 +53,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
-        Id id;
-        try {
-            id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
-        }
+        Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -44,7 +44,7 @@ public class DeleteCommandParserTest {
     }
 
     @Test
-    public void parse_repeatedId_throwsParseException() {
+    public void parse_duplicatePrefix_throwsParseException() {
         // zero id
         assertParseFailure(parser, " i/1 i/2", String.format(getErrorMessageForDuplicatePrefixes(PREFIX_ID)));
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.getErrorMessageForDuplicatePrefixes;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIds.ID_FIRST_PERSON;
@@ -8,6 +10,7 @@ import static seedu.address.testutil.TypicalIds.ID_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.Id;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -26,7 +29,29 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_invalidId_throwsParseException() {
+        // zero id
+        assertParseFailure(parser, " i/0", Id.MESSAGE_CONSTRAINTS);
+
+        // negative id
+        assertParseFailure(parser, " i/-5", Id.MESSAGE_CONSTRAINTS);
+
+        // non numerical id
+        assertParseFailure(parser, " i/one", Id.MESSAGE_CONSTRAINTS);
+
+        // empty id
+        assertParseFailure(parser, " i/", Id.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_repeatedId_throwsParseException() {
+        // zero id
+        assertParseFailure(parser, " i/1 i/2", String.format(getErrorMessageForDuplicatePrefixes(PREFIX_ID)));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -51,7 +51,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
+        assertParseFailure(parser, " a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -30,6 +30,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PREFERENCES;
@@ -86,17 +87,24 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidId_failure() {
-        // negative id
-        assertParseFailure(parser, "i/-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-
         // zero id
-        assertParseFailure(parser, "i/0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " i/0" + NAME_DESC_AMY, Id.MESSAGE_CONSTRAINTS);
 
-        // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "i/1 some random string", MESSAGE_INVALID_FORMAT);
+        // negative id
+        assertParseFailure(parser, " i/-5" + NAME_DESC_AMY, Id.MESSAGE_CONSTRAINTS);
 
-        // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "i/1 k/ string", MESSAGE_INVALID_FORMAT);
+        // non numerical id
+        assertParseFailure(parser, " i/one", Id.MESSAGE_CONSTRAINTS);
+
+        // empty id
+        assertParseFailure(parser, " i/", Id.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_repeatedId_throwsParseException() {
+        // zero id
+        assertParseFailure(parser, " i/1 i/2" + NAME_DESC_AMY,
+                String.format(Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ID)));
     }
 
     @Test
@@ -207,7 +215,7 @@ public class EditCommandParserTest {
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // mulltiple valid fields repeated
+        // multiple valid fields repeated
         userInput = targetId + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;


### PR DESCRIPTION
Fixes #74.

* Output accurate error message for invalid id fields for delete and edit command
  * Previous: If name/id is in the wrong format (e.g. n/Sha@un), error message is "Invalid command format! ..."
  * Fix: If name/id is in the wrong format, error message is "(Name/Id).MESSAGE_CONSTRAINTS"
* Add test to check accurate error message
* Add test to check repeated id value