### PR TITLE
Update NetConnect to allow duplicate names

### DIFF
--- a/src/main/java/seedu/address/model/person/Client.java
+++ b/src/main/java/seedu/address/model/person/Client.java
@@ -59,21 +59,6 @@ public class Client extends Person {
     }
 
     /**
-     * Checks if this client is the same as another person.
-     * Two clients are considered the same if they have the same attributes.
-     *
-     * @param otherPerson The person to compare with.
-     * @return True if the clients are the same, false otherwise.
-     */
-    @Override
-    public boolean isSamePerson(Person otherPerson) {
-        if (!super.isSamePerson(otherPerson)) {
-            return false;
-        }
-        return otherPerson instanceof Client;
-    }
-
-    /**
      * Checks if this client is the same as another client.
      * Two clients are considered the same if they have the same attributes.
      *

--- a/src/main/java/seedu/address/model/person/Employee.java
+++ b/src/main/java/seedu/address/model/person/Employee.java
@@ -71,21 +71,6 @@ public class Employee extends Person {
     }
 
     /**
-     * Checks if this employee is the same as another person.
-     * Two employees are considered the same if they have the same attributes.
-     *
-     * @param otherPerson The person to compare with.
-     * @return True if the employees are the same, false otherwise.
-     */
-    @Override
-    public boolean isSamePerson(Person otherPerson) {
-        if (!super.isSamePerson(otherPerson)) {
-            return false;
-        }
-        return otherPerson instanceof Employee;
-    }
-
-    /**
      * Checks if this employee is equal to another object.
      * Two employees are considered equal if they have the same attributes.
      *

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -110,7 +110,7 @@ public abstract class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same name, phone, and email.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -119,7 +119,9 @@ public abstract class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone())
+                && otherPerson.getEmail().equals(getEmail());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Supplier.java
+++ b/src/main/java/seedu/address/model/person/Supplier.java
@@ -59,21 +59,6 @@ public class Supplier extends Person {
     }
 
     /**
-     * Checks if this supplier is the same as another person.
-     * Two suppliers are considered the same if they have the same attributes.
-     *
-     * @param otherPerson The person to compare with.
-     * @return True if the suppliers are the same, false otherwise.
-     */
-    @Override
-    public boolean isSamePerson(Person otherPerson) {
-        if (!super.isSamePerson(otherPerson)) {
-            return false;
-        }
-        return otherPerson instanceof Supplier;
-    }
-
-    /**
      * Checks if this supplier is equal to another object.
      * Two suppliers are considered equal if they have the same attributes.
      *

--- a/src/test/java/seedu/address/model/NetConnectTest.java
+++ b/src/test/java/seedu/address/model/NetConnectTest.java
@@ -1,6 +1,5 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -131,7 +130,7 @@ public class NetConnectTest {
      * The method asserts that no exceptions are thrown during the process.
      */
     @Test
-    public void addPerson_differentRolesWithSameIdentityFields_handlesCorrectly() {
+    public void addPerson_differentRolesWithSameIdentityFields_throwsDuplicatePersonException() {
         netConnect.addPerson(ALICE);
         Employee aliceEmployee = new EmployeeBuilder().withName(ALICE.getName().toString())
                 .withPhone(ALICE.getPhone().toString())
@@ -141,7 +140,7 @@ public class NetConnectTest {
                 .withJobTitle("Engineer")
                 .build();
 
-        assertDoesNotThrow(() -> netConnect.addPerson(aliceEmployee));
+        assertThrows(DuplicatePersonException.class, () -> netConnect.addPerson(aliceEmployee));
 
         Supplier aliceSupplier = new SupplierBuilder().withName(ALICE.getName().toString())
                 .withPhone(ALICE.getPhone().toString())
@@ -150,11 +149,11 @@ public class NetConnectTest {
                 .withTermsOfService("1 Year Warranty")
                 .build();
 
-        assertDoesNotThrow(() -> netConnect.addPerson(aliceSupplier));
+        assertThrows(DuplicatePersonException.class, () -> netConnect.addPerson(aliceSupplier));
     }
 
     @Test
-    public void hasPerson_diffRolesWithSameIdentityFieldsInNetConnect_returnsFalse() {
+    public void hasPerson_diffRolesWithSameIdentityFieldsInNetConnect_returnsTrue() {
         netConnect.addPerson(ALICE);
         Employee aliceEmployee = new EmployeeBuilder().withName(ALICE.getName().toString())
                 .withPhone(ALICE.getPhone().toString())
@@ -162,7 +161,7 @@ public class NetConnectTest {
                 .withAddress(ALICE.getAddress().toString())
                 .withDepartment("Engineering")
                 .build();
-        assertFalse(netConnect.hasPerson(aliceEmployee));
+        assertTrue(netConnect.hasPerson(aliceEmployee));
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
@@ -31,17 +32,32 @@ public class PersonTest {
         // same object -> returns true
         assertTrue(ALICE.isSamePerson(ALICE));
 
+        // same name, phone, and email -> returns true
+        Person bobCopy = new ClientBuilder()
+                .withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB)
+                .build();
+        assertTrue(BOB.isSamePerson(bobCopy));
+
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
-        Person editedAlice = new ClientBuilder(ALICE).withId(VALID_ID_BOB).withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSamePerson(editedAlice));
+        // same single field of name/phone/email, all other attributes different -> returns false
+        Person sameName = new ClientBuilder(BENSON).withName(ALICE.getName().fullName).build();
+        assertFalse(ALICE.isSamePerson(sameName));
+        Person samePhone = new ClientBuilder(BENSON).withPhone(ALICE.getPhone().value).build();
+        assertFalse(ALICE.isSamePerson(samePhone));
+        Person sameEmail = new ClientBuilder(BENSON).withEmail(ALICE.getEmail().value).build();
+        assertFalse(ALICE.isSamePerson(sameEmail));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new ClientBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        // different single field of name/phone/email, all other attributes same -> returns false
+        Person diffName = new ClientBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertFalse(ALICE.isSamePerson(sameName));
+        Person diffPhone = new ClientBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(ALICE.isSamePerson(samePhone));
+        Person diffEmail = new ClientBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
+        assertFalse(ALICE.isSamePerson(sameEmail));
 
         // name differs in case, all other attributes same -> returns false
         Person editedBob = new EmployeeBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();


### PR DESCRIPTION
Fixes #48.

Changes: 
* Update Person#isSamePerson to only returns true iff name, phone, and email are all the same. This is regardless of role to prevent erroneous creation of person if role is accidentally put wrong.
* Update tests to reflect the change