### PR TITLE
Fix `showrelated` command working for a Person that does not exist

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -39,6 +39,7 @@ you in maximising the capabilities of this product, freeing time for more pressi
     + [Exiting the program : `exit`](#exit-program)
     + [Saving the data](#saving-the-data)
     + [Editing the data file](#editing-the-data-file)
+* [Future Implementations](#future-implementations)
 * [FAQ](#faq)
 * [Known issues](#known-issues)
 * [Command summary](#command-summary)
@@ -308,6 +309,8 @@ Format: `showrelated i/ID`
 
 Example: `showrelated i/1` shows all relations between the profile with ID 1 and all other contacts.
 
+**Info:** If there are no persons related to the provided ID, the interface will show `0 persons listed`.
+
 </section>
 
 <section id="open-on-last-state">
@@ -377,6 +380,9 @@ If your changes to the data file makes its format invalid, NetConnect will disca
 </section>
 
 # Future Implementations
+The NetConnect team is working on new features and fixes for you, but they are unfortunately unavailable in this current implementation. We intend to have future fixes for these occurences below!
+
+1. When invoking showrelated on a id that does not exist, the error message will be `Contact not found` instead of `0 persons listed`.
 
 ## Truncate text in GUI
 Current implementation of NetConnect GUI is able to accommodate input of approximately 120 characters for the profile fields (name, tags, etc.) in fullscreen mode. Additional text are represented by ellipsis. Future implementations will include a feature to truncate text responsively according to the screen size in the GUI to prevent overflow.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,7 +84,7 @@ public interface Model {
     Person getPersonByName(Name name);
 
     /**
-     * Deletes the given person.
+     * Deletes the given person including any of its relations.
      * The person must exist in the address book.
      */
     void deletePerson(Person target);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -172,7 +172,7 @@ public class ModelManager implements Model {
     @Override
     public boolean removeRelatedIdTuple(IdTuple idTuple) {
         requireNonNull(idTuple);
-        return netConnect.removeRelatedId(idTuple);
+        return netConnect.removeRelatedIdTuple(idTuple);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/NetConnect.java
+++ b/src/main/java/seedu/address/model/NetConnect.java
@@ -96,7 +96,7 @@ public class NetConnect implements ReadOnlyNetConnect {
     }
 
     /**
-     * Returns true if the NetConnect has exactly one {@code Person}
+     * Returns count if the NetConnect has exactly one {@code Person}
      * with the specified name.
      */
     public int countPersonsWithName(Name name) {
@@ -139,6 +139,8 @@ public class NetConnect implements ReadOnlyNetConnect {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        Id id = key.getId();
+        relatedList.removeId(id);
     }
 
     //// related list operations
@@ -170,9 +172,9 @@ public class NetConnect implements ReadOnlyNetConnect {
      * @param idTuple The IdTuple to be removed.
      * @return true if the IdTuple is removed, false otherwise.
      */
-    public boolean removeRelatedId(IdTuple idTuple) {
+    public boolean removeRelatedIdTuple(IdTuple idTuple) {
         requireNonNull(idTuple);
-        return relatedList.remove(idTuple);
+        return relatedList.removeTuple(idTuple);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/util/RelatedList.java
+++ b/src/main/java/seedu/address/model/util/RelatedList.java
@@ -151,7 +151,8 @@ public class RelatedList implements Iterable<IdTuple> {
      */
     public void removeId(Id id) {
         requireNonNull(id);
-        relatedPersons.removeIf(idTuple -> idTuple.getFirstPersonId().equals(id) || idTuple.getSecondPersonId().equals(id));
+        relatedPersons.removeIf(idTuple ->
+                idTuple.getFirstPersonId().equals(id) || idTuple.getSecondPersonId().equals(id));
     }
 
     public ObservableList<IdTuple> asUnmodifiableObservableList() {

--- a/src/main/java/seedu/address/model/util/RelatedList.java
+++ b/src/main/java/seedu/address/model/util/RelatedList.java
@@ -103,10 +103,10 @@ public class RelatedList implements Iterable<IdTuple> {
     }
 
     /**
-     * Adds a related person to the list.
+     * Removes a idTuple from the RelatedList.
      *
-     * @param idTuple The related person to be added.
-     * @return True if the related person is added, false otherwise.
+     * @param idTuple The relation to be deleted.
+     * @return True if the relation is deleted, false otherwise.
      */
     public boolean removeTuple(IdTuple idTuple) {
         requireNonNull(idTuple);

--- a/src/main/java/seedu/address/model/util/RelatedList.java
+++ b/src/main/java/seedu/address/model/util/RelatedList.java
@@ -108,7 +108,7 @@ public class RelatedList implements Iterable<IdTuple> {
      * @param idTuple The related person to be added.
      * @return True if the related person is added, false otherwise.
      */
-    public boolean remove(IdTuple idTuple) {
+    public boolean removeTuple(IdTuple idTuple) {
         requireNonNull(idTuple);
         if (relatedPersons.contains(idTuple)) {
             relatedPersons.remove(idTuple);
@@ -142,6 +142,16 @@ public class RelatedList implements Iterable<IdTuple> {
             }
         }
         return relatedIds;
+    }
+
+    /**
+     * Removes the specified ID from the relatedList.
+     *
+     * @param id The ID to be removed.
+     */
+    public void removeId(Id id) {
+        requireNonNull(id);
+        relatedPersons.removeIf(idTuple -> idTuple.getFirstPersonId().equals(id) || idTuple.getSecondPersonId().equals(id));
     }
 
     public ObservableList<IdTuple> asUnmodifiableObservableList() {

--- a/src/main/java/seedu/address/model/util/RelatedList.java
+++ b/src/main/java/seedu/address/model/util/RelatedList.java
@@ -145,7 +145,7 @@ public class RelatedList implements Iterable<IdTuple> {
     }
 
     /**
-     * Removes the specified ID from the relatedList.
+     * Removes all tuples containing specified ID from the relatedList.
      *
      * @param id The ID to be removed.
      */

--- a/src/test/java/seedu/address/model/NetConnectTest.java
+++ b/src/test/java/seedu/address/model/NetConnectTest.java
@@ -192,12 +192,12 @@ public class NetConnectTest {
 
     @Test
     public void removeRelatedId_nullId_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> netConnect.removeRelatedId(null));
+        assertThrows(NullPointerException.class, () -> netConnect.removeRelatedIdTuple(null));
     }
 
     @Test
     public void removeRelatedId_idNotInNetConnect_returnsFalse() {
-        assertFalse(netConnect.removeRelatedId(new IdTuple(ALICE.getId(), BOB.getId())));
+        assertFalse(netConnect.removeRelatedIdTuple(new IdTuple(ALICE.getId(), BOB.getId())));
     }
 
     @Test
@@ -205,7 +205,7 @@ public class NetConnectTest {
         netConnect.addPerson(ALICE);
         netConnect.addPerson(BOB);
         netConnect.allowAddIdTuple(new IdTuple(ALICE.getId(), BOB.getId()));
-        assertTrue(netConnect.removeRelatedId(new IdTuple(ALICE.getId(), BOB.getId())));
+        assertTrue(netConnect.removeRelatedIdTuple(new IdTuple(ALICE.getId(), BOB.getId())));
     }
 
     /**

--- a/src/test/java/seedu/address/model/util/RelatedListTest.java
+++ b/src/test/java/seedu/address/model/util/RelatedListTest.java
@@ -48,13 +48,13 @@ public class RelatedListTest {
     public void remove_relatedListContainsIdTuple_returnsTrue() {
         IdTuple idTuple = new IdTuple(Id.generateTempId(1), Id.generateTempId(2));
         relatedList.allowAddIdTuple(idTuple);
-        assertTrue(relatedList.remove(idTuple));
+        assertTrue(relatedList.removeTuple(idTuple));
     }
 
     @Test
     public void remove_relatedListDoesNotContainIdTuple_returnsFalse() {
         IdTuple idTuple = new IdTuple(Id.generateTempId(1), Id.generateTempId(2));
-        assertFalse(relatedList.remove(idTuple));
+        assertFalse(relatedList.removeTuple(idTuple));
     }
 
     @Test
@@ -68,6 +68,31 @@ public class RelatedListTest {
         assertEquals(2, relatedList.getAllRelatedIds(relatedList, Id.generateTempId(2)).size());
         assertEquals(1, relatedList.getAllRelatedIds(relatedList, Id.generateTempId(3)).size());
     }
+
+    @Test
+    public void removeId_IdExistsAndHasMultipleRelations_success() {
+        IdTuple idTuple = new IdTuple(Id.generateTempId(1), Id.generateTempId(2));
+        IdTuple idTuple2 = new IdTuple(Id.generateTempId(1), Id.generateTempId(3));
+        relatedList.allowAddIdTuple(idTuple);
+        relatedList.allowAddIdTuple(idTuple2);
+
+        relatedList.removeId(Id.generateTempId(1));
+        assertTrue(relatedList.isEmpty());
+    }
+
+    @Test
+    public void removeId_IdHasNoRelations_success() {
+        IdTuple idTuple = new IdTuple(Id.generateTempId(1), Id.generateTempId(2));
+        IdTuple idTuple2 = new IdTuple(Id.generateTempId(1), Id.generateTempId(3));
+        relatedList.allowAddIdTuple(idTuple);
+        relatedList.allowAddIdTuple(idTuple2);
+
+        relatedList.removeId(Id.generateTempId(5));
+        assertTrue(relatedList.hasId(idTuple) && relatedList.hasId(idTuple2));
+        assertEquals(2, relatedList.size());
+    }
+
+
 
     @Test
     public void asUnmodifiableObservableList_returnsUnmodifiableList() {

--- a/src/test/java/seedu/address/model/util/RelatedListTest.java
+++ b/src/test/java/seedu/address/model/util/RelatedListTest.java
@@ -70,7 +70,7 @@ public class RelatedListTest {
     }
 
     @Test
-    public void removeId_IdExistsAndHasMultipleRelations_success() {
+    public void removeId_idExistsAndHasMultipleRelations_returnsUpdatedRelatedList() {
         IdTuple idTuple = new IdTuple(Id.generateTempId(1), Id.generateTempId(2));
         IdTuple idTuple2 = new IdTuple(Id.generateTempId(1), Id.generateTempId(3));
         relatedList.allowAddIdTuple(idTuple);
@@ -81,7 +81,7 @@ public class RelatedListTest {
     }
 
     @Test
-    public void removeId_IdHasNoRelations_success() {
+    public void removeId_idHasNoRelations_noChangeInRelatedList() {
         IdTuple idTuple = new IdTuple(Id.generateTempId(1), Id.generateTempId(2));
         IdTuple idTuple2 = new IdTuple(Id.generateTempId(1), Id.generateTempId(3));
         relatedList.allowAddIdTuple(idTuple);
@@ -89,7 +89,6 @@ public class RelatedListTest {
 
         relatedList.removeId(Id.generateTempId(5));
         assertTrue(relatedList.hasId(idTuple) && relatedList.hasId(idTuple2));
-        assertEquals(2, relatedList.size());
     }
 
 


### PR DESCRIPTION
Fixes #175 .
Fixes #143. 

Deletion of `Person` propagates to `RelatedList` as well. 

Minor changes to improve clarity of code. 