### PR TITLE
Fix views that confuse users on actual command execution

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RelateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RelateCommand.java
@@ -40,9 +40,13 @@ public class RelateCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        // reset user view from any previous commands
+        model.clearFilter();
+
         // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
         model.stackFilters(predicate);
         if (firstPersonId.equals(secondPersonId)) {
+            model.clearFilter();
             throw new CommandException(Messages.MESSAGE_CANNOT_RELATE_ITSELF);
         }
         // actual execution occurs here

--- a/src/main/java/seedu/address/logic/commands/RelateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RelateCommand.java
@@ -40,11 +40,7 @@ public class RelateCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        // reset user view from any previous commands
-        model.clearFilter();
 
-        // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
-        model.stackFilters(predicate);
         if (firstPersonId.equals(secondPersonId)) {
             model.clearFilter();
             throw new CommandException(Messages.MESSAGE_CANNOT_RELATE_ITSELF);
@@ -63,6 +59,12 @@ public class RelateCommand extends Command {
         } else {
             model.addRelatedIdTuple(tuple);
         }
+
+        // reset user view from any previous commands
+        model.clearFilter();
+
+        // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
+        model.stackFilters(predicate);
 
         return new CommandResult(
             String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));

--- a/src/main/java/seedu/address/logic/commands/ShowRelatedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowRelatedCommand.java
@@ -34,10 +34,14 @@ public class ShowRelatedCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         RelatedList relatedList = model.getRelatedIdTuples();
 
         List<Integer> relatedIds = relatedList.getAllRelatedIds(relatedList, id);
         IdContainsDigitsPredicate predicate = new IdContainsDigitsPredicate(relatedIds);
+
+        // reset user view from any previous commands
+        model.clearFilter();
 
         model.stackFilters(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/UnrelateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnrelateCommand.java
@@ -42,9 +42,13 @@ public class UnrelateCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        // reset user view from any previous commands
+        model.clearFilter();
+
         // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
         model.stackFilters(predicate);
         if (firstPersonId.equals(secondPersonId)) {
+            model.clearFilter();
             throw new CommandException(Messages.MESSAGE_CANNOT_UNRELATE_ITSELF);
         }
         // actual execution occurs here

--- a/src/main/java/seedu/address/logic/commands/UnrelateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnrelateCommand.java
@@ -42,11 +42,7 @@ public class UnrelateCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        // reset user view from any previous commands
-        model.clearFilter();
 
-        // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
-        model.stackFilters(predicate);
         if (firstPersonId.equals(secondPersonId)) {
             model.clearFilter();
             throw new CommandException(Messages.MESSAGE_CANNOT_UNRELATE_ITSELF);
@@ -65,6 +61,12 @@ public class UnrelateCommand extends Command {
         } else {
             model.removeRelatedIdTuple(tuple);
         }
+
+        // reset user view from any previous commands
+        model.clearFilter();
+
+        // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
+        model.stackFilters(predicate);
 
         return new CommandResult(String.format(Messages.MESSAGE_UNRELATION_SUCCESS, tuple));
     }


### PR DESCRIPTION
# Bug fixes related to view not refreshing:
- Refresh view so chained commands (not using `list` command to reset view) will not mislead user. See 1. and 2. 
- Remove "successful" single contact viewed despite an invalid reflexive `relate` command. See 3.

1. **Fixes #172** , screenshot of bug submitted by tester below:
<img width="826" alt="image" src="https://github.com/AY2324S2-CS2103T-F12-1/tp/assets/104408800/6b2bc5aa-8d85-4e37-8cc8-8951ca388fcc">

2. **Fixes #160**, screenshot of bug submitted by tester below:
<img width="807" alt="image" src="https://github.com/AY2324S2-CS2103T-F12-1/tp/assets/104408800/97a85426-f430-499d-a619-5add007cf737">

3. **Fixes #145**, screenshot of bug submitted by tester below:
<img width="800" alt="image" src="https://github.com/AY2324S2-CS2103T-F12-1/tp/assets/104408800/7521ffd8-46d8-4ce1-a59c-cf16ae4a1f06">
<img width="823" alt="image" src="https://github.com/AY2324S2-CS2103T-F12-1/tp/assets/104408800/90e1fb0c-121b-45d0-b8f0-67db55c0b610">
