### PR TITLE
Fix find by remark to allow more than one word

### DIFF
--- a/src/main/java/seedu/address/model/person/filter/RemarkContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/filter/RemarkContainsKeywordsPredicate.java
@@ -2,6 +2,7 @@ package seedu.address.model.person.filter;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -36,7 +37,8 @@ public class RemarkContainsKeywordsPredicate extends NetConnectPredicate<Person>
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getRemark().value, keyword))
+                .anyMatch(keyword -> Arrays.stream(keyword.split("\\s+"))
+                        .allMatch(word -> StringUtil.containsWordIgnoreCase(person.getRemark().value, word)))
                 || (hasEmptyKeyword && person.getRemark().value.isBlank());
     }
 

--- a/src/test/java/seedu/address/model/person/filter/RemarkContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/filter/RemarkContainsKeywordsPredicateTest.java
@@ -91,10 +91,27 @@ public class RemarkContainsKeywordsPredicateTest {
 
     @Test
     public void test_remarkContainsKeywords_returnsTrue() {
+        // single word keywords
         RemarkContainsKeywordsPredicate predicate =
                 new RemarkContainsKeywordsPredicate(Arrays.asList("first", "second"));
         assertTrue(predicate.test(new ClientBuilder().withRemark("first").build()));
         assertTrue(predicate.test(new ClientBuilder().withRemark("second").build()));
+
+        // multiple words keywords
+        predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList("the first"));
+        assertTrue(predicate.test(new ClientBuilder().withRemark("this is the first").build()));
+
+        // multiple keywords, separate by other characters in sentence
+        predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList("the first"));
+        assertTrue(predicate.test(new ClientBuilder().withRemark("this is the very first").build()));
+
+        // reverse
+        predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList("first the"));
+        assertTrue(predicate.test(new ClientBuilder().withRemark("this is the very first").build()));
+
+        // mix case
+        predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList("fiRSt"));
+        assertTrue(predicate.test(new ClientBuilder().withRemark("First").build()));
     }
 
     @Test
@@ -123,6 +140,24 @@ public class RemarkContainsKeywordsPredicateTest {
         // Non-empty remark with empty keyword
         predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList(""));
         assertFalse(predicate.test(new ClientBuilder().withRemark("first").build()));
+    }
+
+    @Test
+    public void test_partialWordMatch_returnsFalse() {
+        RemarkContainsKeywordsPredicate predicate =
+                new RemarkContainsKeywordsPredicate(Collections.singletonList("fir"));
+        assertFalse(predicate.test(new ClientBuilder().withRemark("first").build()));
+    }
+
+    @Test
+    public void test_notAllWordsMatch_returnsFalse() {
+        RemarkContainsKeywordsPredicate predicate =
+                new RemarkContainsKeywordsPredicate(Collections.singletonList("the first"));
+        assertFalse(predicate.test(new ClientBuilder().withRemark("this is first").build()));
+
+        // some partial match
+        predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList("the first"));
+        assertFalse(predicate.test(new ClientBuilder().withRemark("this is the firsty").build()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #140.

Previous implementation only allows `r/` to take in one word per `r/`, i.e. does not work for `r/marketing IC`.

Behaviour in this commit:
* find r/has dog matches r/has a dog
* find r/has dog matches r/dog has
* find r/dog does **not** match r/dogs, or vice versa