### PR TITLE
Refactor relate and unrelate

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RelateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RelateCommand.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -23,18 +26,17 @@ public class RelateCommand extends Command {
             + "Parameters: i/ID_1 i/ID_2\n"
             + "Example: " + COMMAND_WORD + " i/4 i/12";
 
-    private final IdContainsDigitsPredicate predicate;
-
     private final Id firstPersonId;
     private final Id secondPersonId;
 
     /**
      * Creates a RelateCommand to relate the two specified {@code IdContainsDigitsPredicate}
      */
-    public RelateCommand(IdContainsDigitsPredicate predicate) {
-        this.predicate = predicate;
-        this.firstPersonId = Id.generateTempId(predicate.getFirstId());
-        this.secondPersonId = Id.generateTempId(predicate.getSecondId());
+    public RelateCommand(Id firstPersonId, Id secondPersonId) {
+        requireAllNonNull(firstPersonId, secondPersonId);
+
+        this.firstPersonId = firstPersonId;
+        this.secondPersonId = secondPersonId;
     }
 
     @Override
@@ -53,18 +55,17 @@ public class RelateCommand extends Command {
         }
 
         IdTuple tuple = new IdTuple(firstPersonId, secondPersonId);
-
         if (model.hasRelatedIdTuple(tuple)) {
             throw new CommandException(Messages.MESSAGE_RELATION_EXISTS);
-        } else {
-            model.addRelatedIdTuple(tuple);
         }
+
+        model.addRelatedIdTuple(tuple);
 
         // reset user view from any previous commands
         model.clearFilter();
 
         // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
-        model.stackFilters(predicate);
+        model.stackFilters(new IdContainsDigitsPredicate(List.of(firstPersonId.value, secondPersonId.value)));
 
         return new CommandResult(
             String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
@@ -82,13 +83,17 @@ public class RelateCommand extends Command {
         }
 
         RelateCommand otherFindNumCommand = (RelateCommand) other;
-        return predicate.equals(otherFindNumCommand.predicate);
+        return (this.firstPersonId.equals(otherFindNumCommand.firstPersonId)
+                && this.secondPersonId.equals(otherFindNumCommand.secondPersonId))
+                || (this.firstPersonId.equals(otherFindNumCommand.secondPersonId)
+                && this.secondPersonId.equals(otherFindNumCommand.firstPersonId));
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("predicate", predicate)
+                .add("first id", firstPersonId)
+                .add("second id", secondPersonId)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnrelateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnrelateCommand.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -25,18 +28,17 @@ public class UnrelateCommand extends Command {
             + "Parameters: i/ID_1 i/ID_2\n"
             + "Example: " + COMMAND_WORD + " i/4 i/12";
 
-    private final IdContainsDigitsPredicate predicate;
-
     private final Id firstPersonId;
     private final Id secondPersonId;
 
     /**
      * Creates a UnrelateCommand to unrelate the two specified {@code IdContainsDigitsPredicate}
      */
-    public UnrelateCommand(IdContainsDigitsPredicate predicate) {
-        this.predicate = predicate;
-        this.firstPersonId = Id.generateTempId(predicate.getFirstId());
-        this.secondPersonId = Id.generateTempId(predicate.getSecondId());
+    public UnrelateCommand(Id firstPersonId, Id secondPersonId) {
+        requireAllNonNull(firstPersonId, secondPersonId);
+
+        this.firstPersonId = firstPersonId;
+        this.secondPersonId = secondPersonId;
     }
 
     @Override
@@ -66,22 +68,34 @@ public class UnrelateCommand extends Command {
         model.clearFilter();
 
         // if ids are valid AND exists, model will display them, otherwise, it will be an empty list
-        model.stackFilters(predicate);
+        model.stackFilters(new IdContainsDigitsPredicate(List.of(firstPersonId.value, secondPersonId.value)));
 
         return new CommandResult(String.format(Messages.MESSAGE_UNRELATION_SUCCESS, tuple));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this
-                || (other instanceof UnrelateCommand
-                && predicate.equals(((UnrelateCommand) other).predicate));
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UnrelateCommand)) {
+            return false;
+        }
+
+        UnrelateCommand otherFindNumCommand = (UnrelateCommand) other;
+        return (this.firstPersonId.equals(otherFindNumCommand.firstPersonId)
+                && this.secondPersonId.equals(otherFindNumCommand.secondPersonId))
+                || (this.firstPersonId.equals(otherFindNumCommand.secondPersonId)
+                && this.secondPersonId.equals(otherFindNumCommand.firstPersonId));
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("predicate", predicate)
+                .add("first id", firstPersonId)
+                .add("second id", secondPersonId)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/RelateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RelateCommandParser.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
-import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.RelateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.filter.IdContainsDigitsPredicate;
 
 /**
  * Parses input arguments and creates a new RelateCommand object
@@ -20,35 +20,12 @@ public class RelateCommandParser implements Parser<RelateCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public RelateCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID);
+        List<String> ids = argMultimap.getAllValues(PREFIX_ID);
+        if (ids.size() != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
         }
 
-        String[] providedIds = trimmedArgs.split("\\s+");
-
-        if (providedIds.length != 2) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
-        }
-
-        String[] pureIds = new String[2];
-
-        for (int i = 0; i < providedIds.length; i++) {
-            String[] flagAndId = providedIds[i].split("/");
-            // find and validate flag
-            if (flagAndId[0].equals("i")) {
-                ParserUtil.parseId(flagAndId[1]);
-                pureIds[i] = flagAndId[1];
-            } else {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
-            }
-        }
-
-        Integer[] providedIdsAsInt = Arrays.stream(pureIds).map(Integer::parseInt).toArray(Integer[]::new);
-
-        return new RelateCommand(new IdContainsDigitsPredicate(Arrays.asList(providedIdsAsInt)));
+        return new RelateCommand(ParserUtil.parseId(ids.get(0)), ParserUtil.parseId(ids.get(1)));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ShowRelatedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowRelatedCommandParser.java
@@ -28,13 +28,8 @@ public class ShowRelatedCommandParser implements Parser<ShowRelatedCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowRelatedCommand.MESSAGE_USAGE));
         }
 
-        try {
-            Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-            return new ShowRelatedCommand(id);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT, ShowRelatedCommand.MESSAGE_USAGE), pe);
-        }
+        Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
+        return new ShowRelatedCommand(id);
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/ShowRelatedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowRelatedCommandParser.java
@@ -28,8 +28,13 @@ public class ShowRelatedCommandParser implements Parser<ShowRelatedCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowRelatedCommand.MESSAGE_USAGE));
         }
 
-        Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
-        return new ShowRelatedCommand(id);
+        try {
+            Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
+            return new ShowRelatedCommand(id);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, ShowRelatedCommand.MESSAGE_USAGE), pe);
+        }
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/UnrelateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnrelateCommandParser.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
-import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.UnrelateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.filter.IdContainsDigitsPredicate;
 
 /**
  * Parses input arguments and creates a new RelateCommand object
@@ -20,35 +20,12 @@ public class UnrelateCommandParser implements Parser<UnrelateCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public UnrelateCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID);
+        List<String> ids = argMultimap.getAllValues(PREFIX_ID);
+        if (ids.size() != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
         }
 
-        String[] providedIds = trimmedArgs.split("\\s+");
-
-        if (providedIds.length != 2) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
-        }
-
-        String[] pureIds = new String[2];
-
-        for (int i = 0; i < providedIds.length; i++) {
-            String[] flagAndId = providedIds[i].split("/");
-            // find and validate flag
-            if (flagAndId[0].equals("i")) {
-                ParserUtil.parseId(flagAndId[1]);
-                pureIds[i] = flagAndId[1];
-            } else {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
-            }
-        }
-
-        Integer[] providedIdsAsInt = Arrays.stream(pureIds).map(Integer::parseInt).toArray(Integer[]::new);
-
-        return new UnrelateCommand(new IdContainsDigitsPredicate(Arrays.asList(providedIdsAsInt)));
+        return new UnrelateCommand(ParserUtil.parseId(ids.get(0)), ParserUtil.parseId(ids.get(1)));
     }
 }

--- a/src/main/java/seedu/address/model/person/filter/IdContainsDigitsPredicate.java
+++ b/src/main/java/seedu/address/model/person/filter/IdContainsDigitsPredicate.java
@@ -16,14 +16,6 @@ public class IdContainsDigitsPredicate extends NetConnectPredicate<Person> {
         this.ids = ids;
     }
 
-    public int getFirstId() {
-        return ids.get(0);
-    }
-
-    public int getSecondId() {
-        return ids.get(1);
-    }
-
     @Override
     public String formatFilter() {
         return ids.stream()

--- a/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
@@ -104,7 +104,7 @@ public class RelateCommandTest {
     public void equals() {
         RelateCommand relateFirstSecond = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         RelateCommand otherRelateFirstSecond = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
-        RelateCommand relateSecondFirst = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
+        RelateCommand relateSecondFirst = new RelateCommand(ID_SECOND_PERSON, ID_FIRST_PERSON);
         RelateCommand relateSecondThird = new RelateCommand(ID_SECOND_PERSON, ID_THIRD_PERSON);
         AddCommand addCommand = new AddCommand(new ClientBuilder().build());
 

--- a/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
@@ -102,12 +102,9 @@ public class RelateCommandTest {
 
     @Test
     public void equals() {
-        IdContainsDigitsPredicate predicate1 = new IdContainsDigitsPredicate(List.of(ID_FIRST_PERSON.value,
-                ID_SECOND_PERSON.value));
-        IdContainsDigitsPredicate predicate2 = new IdContainsDigitsPredicate(List.of(ID_SECOND_PERSON.value,
-                ID_THIRD_PERSON.value));
         RelateCommand relateFirstSecond = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         RelateCommand otherRelateFirstSecond = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
+        RelateCommand relateSecondFirst = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         RelateCommand relateSecondThird = new RelateCommand(ID_SECOND_PERSON, ID_THIRD_PERSON);
         AddCommand addCommand = new AddCommand(new ClientBuilder().build());
 
@@ -116,6 +113,9 @@ public class RelateCommandTest {
 
         // same values -> returns true
         assertTrue(relateFirstSecond.equals(otherRelateFirstSecond));
+
+        // same values, diff order -> returns true
+        assertTrue(relateFirstSecond.equals(relateSecondFirst));
 
         // different types -> returns false
         assertFalse(relateFirstSecond.equals(1));

--- a/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
@@ -105,6 +105,8 @@ public class RelateCommandTest {
         RelateCommand relateFirstSecond = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         RelateCommand otherRelateFirstSecond = new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         RelateCommand relateSecondFirst = new RelateCommand(ID_SECOND_PERSON, ID_FIRST_PERSON);
+        RelateCommand relateFirstThird = new RelateCommand(ID_FIRST_PERSON, ID_THIRD_PERSON);
+        RelateCommand relateThirdSecond = new RelateCommand(ID_THIRD_PERSON, ID_SECOND_PERSON);
         RelateCommand relateSecondThird = new RelateCommand(ID_SECOND_PERSON, ID_THIRD_PERSON);
         AddCommand addCommand = new AddCommand(new ClientBuilder().build());
 
@@ -116,6 +118,12 @@ public class RelateCommandTest {
 
         // same values, diff order -> returns true
         assertTrue(relateFirstSecond.equals(relateSecondFirst));
+
+        // first same, second diff -> returns false
+        assertFalse(relateFirstSecond.equals(relateFirstThird));
+
+        // first diff, second same -> returns false
+        assertFalse(relateFirstSecond.equals(relateThirdSecond));
 
         // different types -> returns false
         assertFalse(relateFirstSecond.equals(1));

--- a/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RelateCommandTest.java
@@ -119,12 +119,6 @@ public class RelateCommandTest {
         // same values, diff order -> returns true
         assertTrue(relateFirstSecond.equals(relateSecondFirst));
 
-        // first same, second diff -> returns false
-        assertFalse(relateFirstSecond.equals(relateFirstThird));
-
-        // first diff, second same -> returns false
-        assertFalse(relateFirstSecond.equals(relateThirdSecond));
-
         // different types -> returns false
         assertFalse(relateFirstSecond.equals(1));
 
@@ -136,6 +130,12 @@ public class RelateCommandTest {
 
         // different command -> returns false
         assertFalse(relateFirstSecond.equals(addCommand));
+
+        // only one value match -> returns false
+        assertFalse(relateFirstSecond.equals(relateFirstThird));
+        assertFalse(relateFirstSecond.equals(relateThirdSecond));
+        assertFalse(relateFirstSecond.equals(relateSecondThird));
+        assertFalse(relateSecondThird.equals(relateFirstSecond));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
@@ -92,6 +92,7 @@ public class UnrelateCommandTest {
     public void equals() {
         UnrelateCommand unrelateFirstSecond = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         UnrelateCommand otherUnrelateFirstSecond = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
+        UnrelateCommand unrelateSecondFirst = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         UnrelateCommand unrelateSecondThird = new UnrelateCommand(ID_SECOND_PERSON, ID_THIRD_PERSON);
 
         // same object -> returns true
@@ -99,6 +100,9 @@ public class UnrelateCommandTest {
 
         // same values -> returns true
         assertTrue(unrelateFirstSecond.equals(otherUnrelateFirstSecond));
+
+        // same values, diff order -> returns true
+        assertTrue(unrelateFirstSecond.equals(unrelateSecondFirst));
 
         // different types -> returns false
         assertFalse(unrelateFirstSecond.equals(1));

--- a/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
@@ -93,6 +93,8 @@ public class UnrelateCommandTest {
         UnrelateCommand unrelateFirstSecond = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         UnrelateCommand otherUnrelateFirstSecond = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         UnrelateCommand unrelateSecondFirst = new UnrelateCommand(ID_SECOND_PERSON, ID_FIRST_PERSON);
+        UnrelateCommand unrelateFirstThird = new UnrelateCommand(ID_FIRST_PERSON, ID_THIRD_PERSON);
+        UnrelateCommand unrelateThirdSecond = new UnrelateCommand(ID_THIRD_PERSON, ID_SECOND_PERSON);
         UnrelateCommand unrelateSecondThird = new UnrelateCommand(ID_SECOND_PERSON, ID_THIRD_PERSON);
 
         // same object -> returns true
@@ -103,6 +105,12 @@ public class UnrelateCommandTest {
 
         // same values, diff order -> returns true
         assertTrue(unrelateFirstSecond.equals(unrelateSecondFirst));
+
+        // first same, second diff -> returns false
+        assertFalse(unrelateFirstSecond.equals(unrelateFirstThird));
+
+        // first diff, second same -> returns false
+        assertFalse(unrelateFirstSecond.equals(unrelateThirdSecond));
 
         // different types -> returns false
         assertFalse(unrelateFirstSecond.equals(1));

--- a/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
@@ -92,7 +92,7 @@ public class UnrelateCommandTest {
     public void equals() {
         UnrelateCommand unrelateFirstSecond = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
         UnrelateCommand otherUnrelateFirstSecond = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
-        UnrelateCommand unrelateSecondFirst = new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON);
+        UnrelateCommand unrelateSecondFirst = new UnrelateCommand(ID_SECOND_PERSON, ID_FIRST_PERSON);
         UnrelateCommand unrelateSecondThird = new UnrelateCommand(ID_SECOND_PERSON, ID_THIRD_PERSON);
 
         // same object -> returns true

--- a/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnrelateCommandTest.java
@@ -106,12 +106,6 @@ public class UnrelateCommandTest {
         // same values, diff order -> returns true
         assertTrue(unrelateFirstSecond.equals(unrelateSecondFirst));
 
-        // first same, second diff -> returns false
-        assertFalse(unrelateFirstSecond.equals(unrelateFirstThird));
-
-        // first diff, second same -> returns false
-        assertFalse(unrelateFirstSecond.equals(unrelateThirdSecond));
-
         // different types -> returns false
         assertFalse(unrelateFirstSecond.equals(1));
 
@@ -120,6 +114,12 @@ public class UnrelateCommandTest {
 
         // different values -> returns false
         assertFalse(unrelateFirstSecond.equals(unrelateSecondThird));
+
+        // only one value match -> returns false
+        assertFalse(unrelateFirstSecond.equals(unrelateFirstThird));
+        assertFalse(unrelateFirstSecond.equals(unrelateThirdSecond));
+        assertFalse(unrelateFirstSecond.equals(unrelateSecondThird));
+        assertFalse(unrelateSecondThird.equals(unrelateFirstSecond));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/RelateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RelateCommandParserTest.java
@@ -8,29 +8,29 @@ import static seedu.address.testutil.TypicalIds.ID_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.UnrelateCommand;
+import seedu.address.logic.commands.RelateCommand;
 
-public class UnrelateCommandParserTest {
+public class RelateCommandParserTest {
 
-    private final UnrelateCommandParser parser = new UnrelateCommandParser();
+    private final RelateCommandParser parser = new RelateCommandParser();
 
     @Test
-    public void parse_validArgs_returnsUnrelateCommand() {
+    public void parse_validArgs_returnsRelateCommand() {
         assertParseSuccess(parser, " i/1 i/2",
-                new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON));
+                new RelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                UnrelateCommand.MESSAGE_USAGE));
+                RelateCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " i/1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                UnrelateCommand.MESSAGE_USAGE));
+                RelateCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " i/1 i/2 i/3",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " i/1 i/2 i/3 i/4",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " i/1 i/2 i/3 i/4 i/5",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
@@ -3,13 +3,12 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-
-import java.util.Arrays;
+import static seedu.address.testutil.TypicalIds.ID_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIds.ID_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.UnrelateCommand;
-import seedu.address.model.person.filter.IdContainsDigitsPredicate;
 
 public class UnrelateCommandParserTest {
 
@@ -17,21 +16,21 @@ public class UnrelateCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsUnrelateCommand() {
-        assertParseSuccess(parser, "i/1 i/2",
-                new UnrelateCommand(new IdContainsDigitsPredicate(Arrays.asList(1, 2))));
+        assertParseSuccess(parser, " i/1 i/2",
+                new UnrelateCommand(ID_FIRST_PERSON, ID_SECOND_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 UnrelateCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "i/1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, " i/1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 UnrelateCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "i/1 i/2 i/3",
+        assertParseFailure(parser, " i/1 i/2 i/3",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "i/1 i/2 i/3 i/4",
+        assertParseFailure(parser, " i/1 i/2 i/3 i/4",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "i/1 i/2 i/3 i/4 i/5",
+        assertParseFailure(parser, " i/1 i/2 i/3 i/4 i/5",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
@@ -33,4 +33,12 @@ public class UnrelateCommandParserTest {
         assertParseFailure(parser, " i/1 i/2 i/3 i/4 i/5",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_invalidArgumentLength_throwsParseException() {
+        assertParseFailure(parser, " i/1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " i/1 i/2 i/3",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+    }
 }


### PR DESCRIPTION
Fix #214.

* Remove IdContainsDigitsPredicate#getFirstId and #getSecondId
* Constructor of relate and unrelate to take in two ids
* Use ArgumentTokenizer in relate and unrelate parser
* Using `ParserUtil.parseId(...)` will include the changes done in #213 to check for invalid prefixes
* ~~Fix inaccurate error message for showrelated command~~ **REVERTED**: can't be fixed by v1.4 constraints