### PR TITLE
Allow jobtitle, department, product and skills to accept empty string

### DIFF
--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Department {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Department names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Department names should only contain alphanumeric characters and spaces.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}-][\\p{Alnum}- ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}- ]*";
 
     private final String departmentName;
 

--- a/src/main/java/seedu/address/model/person/JobTitle.java
+++ b/src/main/java/seedu/address/model/person/JobTitle.java
@@ -11,8 +11,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class JobTitle {
 
     public static final String MESSAGE_CONSTRAINTS = "Job titles should only contain "
-            + "alphanumeric characters and spaces, and it should not be blank";
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}-][\\p{Alnum}- ]*";
+            + "alphanumeric characters and spaces.";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}- ]*";
     private final String title;
 
     /**

--- a/src/main/java/seedu/address/model/person/Products.java
+++ b/src/main/java/seedu/address/model/person/Products.java
@@ -45,7 +45,7 @@ public class Products {
      * @return {@code true} if all products are alphanumeric, {@code false} otherwise.
      */
     public static boolean isValidProducts(List<String> test) {
-        return test.stream().allMatch(product -> product.matches("[\\p{Alnum} ]+"));
+        return test.stream().allMatch(product -> product.matches("[\\p{Alnum}- ]*"));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Skills.java
+++ b/src/main/java/seedu/address/model/person/Skills.java
@@ -10,7 +10,8 @@ import java.util.Set;
  */
 public class Skills {
 
-    public static final String MESSAGE_CONSTRAINTS = "Skills should only contain alphanumeric characters and spaces";
+    public static final String MESSAGE_CONSTRAINTS = "Skills should only contain alphanumeric characters "
+            + "+, #, -, and spaces";
 
     private final Set<String> skills;
 
@@ -42,7 +43,7 @@ public class Skills {
     }
 
     public static boolean isValidSkills(String test) {
-        return test.matches("[\\p{Alnum}+#\\- ]+");
+        return test.matches("[\\p{Alnum}+#\\- ]*");
     }
 
     public Set<String> getSkills() {

--- a/src/test/java/seedu/address/model/person/DepartmentTest.java
+++ b/src/test/java/seedu/address/model/person/DepartmentTest.java
@@ -12,13 +12,15 @@ public class DepartmentTest {
         assertTrue(Department.isValidDepartment("Sales"));
         assertTrue(Department.isValidDepartment("Marketing Department"));
         assertTrue(Department.isValidDepartment("123 Department"));
+        assertTrue(Department.isValidDepartment(""));
+        assertTrue(Department.isValidDepartment(" "));
     }
 
     @Test
     public void isValidDepartment_invalidDepartment_returnsFalse() {
-        assertFalse(Department.isValidDepartment(""));
-        assertFalse(Department.isValidDepartment(" "));
         assertFalse(Department.isValidDepartment("Department!"));
+        assertFalse(Department.isValidDepartment("Department@"));
+        assertFalse(Department.isValidDepartment("$&@*#"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/JobTitleTest.java
+++ b/src/test/java/seedu/address/model/person/JobTitleTest.java
@@ -12,8 +12,6 @@ public class JobTitleTest {
     public static final String VALID_JOB_TITLE = "Software Engineer";
     public static final String VALID_JOB_TITLE_2 = "Product Manager";
 
-    public static final String INVALID_JOB_TITLE = "Software Engineer!";
-
     @Test
     public void isValidJobTitle() {
         // Valid job titles
@@ -22,11 +20,13 @@ public class JobTitleTest {
         assertTrue(JobTitle.isValidJobTitle("Data Analyst"));
         assertTrue(JobTitle.isValidJobTitle("Senior Software Developer"));
         assertTrue(JobTitle.isValidJobTitle("123"));
+        assertTrue(JobTitle.isValidJobTitle(""));
+        assertTrue(JobTitle.isValidJobTitle(" "));
 
         // Invalid job titles
-        assertFalse(JobTitle.isValidJobTitle(""));
-        assertFalse(JobTitle.isValidJobTitle(" "));
         assertFalse(JobTitle.isValidJobTitle("INVALID_JOB_TITLE"));
+        assertFalse(JobTitle.isValidJobTitle("Software Engineer!"));
+        assertFalse(JobTitle.isValidJobTitle("&$@*($#()@846!87@"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/ProductsTest.java
+++ b/src/test/java/seedu/address/model/person/ProductsTest.java
@@ -15,10 +15,12 @@ public class ProductsTest {
 
     private static final List<String> PRODUCT_LIST = Arrays.asList("Product1", "Product2", "Product3");
     private static final List<String> EMPTY_LIST = List.of();
+    private static final List<String> EMPTY_STRING_PRODUCT_LIST = Arrays.asList("", " ", "  ");
     private static final String PRODUCT_STRING = "Product1 Product2 Product3";
     private static final String EMPTY_STRING = "";
 
     private Products products;
+    private Products emptyProducts;
 
     @BeforeEach
     public void setUp() {
@@ -34,6 +36,9 @@ public class ProductsTest {
     public void constructor_validList_success() {
         products = new Products(PRODUCT_LIST);
         assertEquals(PRODUCT_LIST, products.getProducts());
+
+        emptyProducts = new Products(EMPTY_STRING_PRODUCT_LIST);
+        assertEquals(EMPTY_STRING_PRODUCT_LIST, emptyProducts.getProducts());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/SkillsTest.java
+++ b/src/test/java/seedu/address/model/person/SkillsTest.java
@@ -40,6 +40,9 @@ public class SkillsTest {
     @Test
     public void isValidSkills_validSkills_returnsTrue() {
         assertTrue(Skills.isValidSkills("Java Python"));
+        assertTrue(Skills.isValidSkills("123"));
+        assertTrue(Skills.isValidSkills(""));
+        assertTrue(Skills.isValidSkills(" "));
     }
 
     @Test


### PR DESCRIPTION
* Allow `jobtitle` to accept empty string / argument
* Allow `department` to accept empty string / argument
* Allow `product` to accept empty string / argument (NOTE: `edit i/1 prod/   prod/  ` will products results like products: ` ,  `)
* Allow `skills` to accept empty string / argument / and certain special characters (to accommodate stuff like C++)


Updated test cases.
