### PR TITLE
Correct error message for editing role

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -48,6 +48,10 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
+        if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
+            throw new ParseException("Role cannot be edited");
+        }
+
         if (argMultimap.getValue(PREFIX_ID).isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -17,6 +17,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ROLE_DESC_CLIENT;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
@@ -137,6 +138,9 @@ public class EditCommandParserTest {
         assertParseFailure(parser,
                 ID_DESC_AMY + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
+
+        // role provided
+        assertParseFailure(parser, ID_DESC_AMY + ROLE_DESC_CLIENT, "Role cannot be edited");
     }
 
     @Test


### PR DESCRIPTION
Fix #157. 

Bug:
![image](https://github.com/AY2324S2-CS2103T-F12-1/tp/assets/93519596/d3d650f2-24ff-4d65-a34c-88725333777f)


I think it can be fixed since it kinda makes it unusable for typical users if they don't know how to fix their command output.
![image](https://github.com/AY2324S2-CS2103T-F12-1/tp/assets/93519596/a2f9eb93-a6f1-465a-8829-636aace351cb)
