### PR TITLE
DeveloperGuide: Fix diagram path for ExportCommandDiagram

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -182,11 +182,11 @@ A `ExportCommand` instance is created in the `ExportCommandParser#parse(...)` me
 
 The sequence diagram below illustrates the execution of a `ExportCommand`:
 
-<puml src="ExportCommandSequenceDiagram.puml" alt="ExportCommandSequenceDiagram" />
+<puml src="diagrams/ExportCommandSequenceDiagram.puml" alt="ExportCommandSequenceDiagram" />
 
 The sequence diagram below illustrates the creation and execution of a `CsvExporter`:
 
-<puml src="ExportCommandSequenceDiagram.puml" alt="CsvExporterSequenceDiagram" />
+<puml src="diagrams/ExportCommandSequenceDiagram.puml" alt="CsvExporterSequenceDiagram" />
 
 #### Design Considerations
 


### PR DESCRIPTION
Previous: the diagram were not shown because the path is incorrect.

Expected: the path was edited.