### PR TITLE
Revert refactor of RelateCommandParser and UnrelateCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/RelateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RelateCommandParser.java
@@ -1,12 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-
-import java.util.List;
 
 import seedu.address.logic.commands.RelateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Id;
 
 /**
  * Parses input arguments and creates a new RelateCommand object
@@ -20,12 +18,32 @@ public class RelateCommandParser implements Parser<RelateCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public RelateCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID);
-        List<String> ids = argMultimap.getAllValues(PREFIX_ID);
-        if (ids.size() != 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
         }
 
-        return new RelateCommand(ParserUtil.parseId(ids.get(0)), ParserUtil.parseId(ids.get(1)));
+        String[] providedIds = trimmedArgs.split("\\s+");
+
+        if (providedIds.length != 2) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
+        }
+
+        Id[] ids = new Id[2];
+
+        for (int i = 0; i < providedIds.length; i++) {
+            String[] flagAndId = providedIds[i].split("/");
+            // find and validate flag
+            if (flagAndId[0].equals("i")) {
+                ids[i] = ParserUtil.parseId(flagAndId[1]);
+            } else {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
+            }
+        }
+
+        return new RelateCommand(ids[0], ids[1]);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnrelateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnrelateCommandParser.java
@@ -1,9 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-
-import java.util.List;
 
 import seedu.address.logic.commands.UnrelateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/UnrelateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnrelateCommandParser.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.address.logic.commands.UnrelateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Id;
 
 /**
  * Parses input arguments and creates a new RelateCommand object
@@ -20,12 +21,32 @@ public class UnrelateCommandParser implements Parser<UnrelateCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public UnrelateCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID);
-        List<String> ids = argMultimap.getAllValues(PREFIX_ID);
-        if (ids.size() != 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
         }
 
-        return new UnrelateCommand(ParserUtil.parseId(ids.get(0)), ParserUtil.parseId(ids.get(1)));
+        String[] providedIds = trimmedArgs.split("\\s+");
+
+        if (providedIds.length != 2) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+        }
+
+        Id[] ids = new Id[2];
+
+        for (int i = 0; i < providedIds.length; i++) {
+            String[] flagAndId = providedIds[i].split("/");
+            // find and validate flag
+            if (flagAndId[0].equals("i")) {
+                ids[i] = ParserUtil.parseId(flagAndId[1]);
+            } else {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+            }
+        }
+
+        return new UnrelateCommand(ids[0], ids[1]);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/RelateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RelateCommandParserTest.java
@@ -32,5 +32,7 @@ public class RelateCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " i/1 i/2 i/3 i/4 i/5",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " n/John n/Roy",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RelateCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.testutil.TypicalIds.ID_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.RelateCommand;
 import seedu.address.logic.commands.UnrelateCommand;
 
 public class UnrelateCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnrelateCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIds.ID_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.RelateCommand;
 import seedu.address.logic.commands.UnrelateCommand;
 
 public class UnrelateCommandParserTest {
@@ -31,6 +32,8 @@ public class UnrelateCommandParserTest {
         assertParseFailure(parser, " i/1 i/2 i/3 i/4",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " i/1 i/2 i/3 i/4 i/5",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " n/John n/Roy",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnrelateCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Revert to not use ArgumentTokenizer. This is to adhere to the constraints of bug fixing in v1.4. This reintroduces the bug mentioned in #155.